### PR TITLE
fix some highlight error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-tcl",
   "displayName": "Tcl",
   "description": "Tcl syntax highlighting",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "bkromhout",
   "engines": {
     "vscode": "^1.36.0"

--- a/syntax.iro
+++ b/syntax.iro
@@ -267,7 +267,7 @@ braced : context {
       regex          \= ((?<!\\)\{)
       styles []       = .punctuation;
       : pop {
-         regex       \= (\}([^\s\]]*))
+         regex       \= (\}([^\s\]"]*))
          styles []    = .punctuation;
       }
       : pattern {

--- a/syntax.iro
+++ b/syntax.iro
@@ -150,7 +150,7 @@ command : context {
    : include "keywords";
    : pattern {
       description     = "All other commands. (NOTE: Iro doesn't support possessive quantifiers, but the grammar does; be sure to replace the second + with ++ after regenerating!)";
-      regex          \= (^\s*\S+|(?:(?<=[^\\]\[)[^\s\]]+(?!\])))
+      regex          \= (^\s*[^\s"]+|(?:(?<=[^\\]\[)[^\s\]]+))
       styles []       = .command;
    }
    : include "args";

--- a/syntaxes/tcl.tmLanguage
+++ b/syntaxes/tcl.tmLanguage
@@ -77,7 +77,7 @@
             </dict>
            </array>
           <key>end</key>
-          <string>(\}([^\s\]]*))</string>
+          <string>(\}([^\s\]\x{0022}]*))</string>
           <key>endCaptures</key>
           <dict>
             <key>1</key>
@@ -291,7 +291,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>(^\s*\S+|(?:(?&lt;=[^\x{005c}]\[)[^\s\]]++(?!\])))</string>
+          <string>(^\s*\S+|(?:(?&lt;=[^\x{005c}]\[)[^\s\]]+(?!\])))</string>
           <key>name</key>
           <string>keyword.tcl</string>
           <key>comment</key>

--- a/syntaxes/tcl.tmLanguage
+++ b/syntaxes/tcl.tmLanguage
@@ -291,7 +291,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>(^\s*\S+|(?:(?&lt;=[^\x{005c}]\[)[^\s\]]+(?!\])))</string>
+          <string>(^\s*[^\s\x{0022}]+|(?:(?&lt;=[^\x{005c}]\[)[^\s\]]+))</string>
           <key>name</key>
           <string>keyword.tcl</string>
           <key>comment</key>


### PR DESCRIPTION
1. when {} used in string(e.g. "{}"), the closed " will be interpret to punctuation type token

before fix:
![image](https://user-images.githubusercontent.com/13173904/133718053-8d04dadf-3eaa-40b2-b165-e3234a485ff3.png)

after fix:
![image](https://user-images.githubusercontent.com/13173904/133718150-27724fa5-db53-42d8-84e2-7652bb7e5169.png)

2. miss match the last char for command
before fix:
<img width="300" alt="bf23eef40618fa5c5c7907fa9a6b671" src="https://user-images.githubusercontent.com/13173904/133720738-27c1fbfa-1c11-4aa5-ad7e-58ca787508ab.png">

3. treat the string to command error
before fix:
<img width="304" alt="9f35e1d9449054c12acdf5b40f20772" src="https://user-images.githubusercontent.com/13173904/133720788-64178dbe-256f-4332-bdcb-dce18be22a49.png">

after fix:
![image](https://user-images.githubusercontent.com/13173904/133720864-a5176a87-1487-4e46-9efd-1951d5b74e96.png)
